### PR TITLE
Performance improvements and fixes

### DIFF
--- a/src/RegisterHindsight.jl
+++ b/src/RegisterHindsight.jl
@@ -204,15 +204,15 @@ function optimize!(ϕ::InterpolatingDeformation, dp::DeformationPenalty, fixed, 
     pold, p0
 end
 
-function optimize!(ϕ::InterpolatingDeformation, dp::DeformationPenalty, fixed, moving::AbstractInterpolation; stepsize = 1.0)
+function optimize!(ϕ::InterpolatingDeformation, dp::DeformationPenalty, fixed, moving::AbstractInterpolation; kwargs...)
     emoving = extrapolate(moving, NaN)
-    optimize!(ϕ, dp, fixed, emoving; stepsize=stepsize)
+    optimize!(ϕ, dp, fixed, emoving; kwargs...)
 end
 
-function optimize!(ϕ::InterpolatingDeformation, dp::DeformationPenalty, fixed, moving::AbstractArray; stepsize = 1.0)
+function optimize!(ϕ::InterpolatingDeformation, dp::DeformationPenalty, fixed, moving::AbstractArray; kwargs...)
     # imoving = interpolate(moving, BSpline(Quadratic(Flat(OnCell()))))
     imoving = interpolate(moving, BSpline(Linear()))
-    optimize!(ϕ, dp, fixed, imoving; stepsize=stepsize)
+    optimize!(ϕ, dp, fixed, imoving; kwargs...)
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,7 +42,7 @@ end
 
     test_hindsight(fixed, moving, ϕ0, ap)
 
-    u0 = rand(1, gridsize...)./10
+    u0 = reshape([isodd(i) ? 0.05 : 0.1 for i = 1:gridsize[1]], 1, gridsize...)
     ϕ0 = GridDeformation(u0, nodes)
     test_hindsight(fixed, moving, ϕ0, ap)
 
@@ -50,6 +50,14 @@ end
     ϕ = interpolate!(copy(ϕ0))      # *not* the same as `interpolate(ϕref)`
     p, p0 = RegisterHindsight.optimize!(ϕ, ap, fixed, emoving; stepsize=0.1)
     @test ratio(mismatch0(fixed, moving),1) > ratio(mismatch0(fixed, warp(moving, ϕ)), 1)
+    @test p0 > 10p
+    ϕ = interpolate!(copy(ϕ0))      # *not* the same as `interpolate(ϕref)`
+    p, p0 = RegisterHindsight.optimize!(ϕ, ap, fixed, emoving; itermax=2)
+    @test p0 < 2p
+
+    ϕ = interpolate!(copy(ϕ0))      # *not* the same as `interpolate(ϕref)`
+    p, p0 = RegisterHindsight.optimize!(ϕ, ap, fixed, moving; itermax=2)
+    @test p0 < 2p
 end
 
 @testset "2-dimensional" begin


### PR DESCRIPTION
In three dimensions Julia's optimizer just wasn't doing what it should have been. This should greatly improve performance. It's better anyway, since this defers some computations until after a `NaN` check on the array access.

CC @ChantalJuntao 